### PR TITLE
chore: upgrade project to Zig 0.15.1

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.1
 
       - name: "Run the tests."
         run: zig test src/tests.zig

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .qbe,
     .version = "0.1.0",
     .fingerprint = 0xc0614787cc68094a,
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -15,7 +15,7 @@ const Statement = @import("root.zig").Statement;
 const DataItem = @import("root.zig").DataItem;
 
 fn testFmtEquals(T: type, value: T, expected: []const u8) !void {
-    const string = try std.fmt.allocPrint(testing.allocator, "{}", .{value});
+    const string = try std.fmt.allocPrint(testing.allocator, "{f}", .{value});
     defer testing.allocator.free(string);
     try testing.expectEqualSlices(u8, expected, string);
 }
@@ -197,7 +197,7 @@ test "module fmt order" {
     });
     _ = try module.addData(data);
 
-    const formatted = try std.fmt.allocPrint(testing.allocator, "{}", .{module});
+    const formatted = try std.fmt.allocPrint(testing.allocator, "{f}", .{module});
     defer testing.allocator.free(formatted);
 
     const type_pos = std.mem.indexOf(u8, formatted, ":test_type") orelse {


### PR DESCRIPTION
this PR upgrades the project to Zig 0.15.1, updating code, tests, CI, and documentation to match the latest language changes.

### What's Changed

* updates `src/root.zig` to use the new writer and allocator APIs
* updates `src/test.zig` to reflect allocator and ArrayList changes
* bumps `minimum_zig_version` in `build.zig.zon` to `0.15.1`